### PR TITLE
Update remote interactions and loader semantics

### DIFF
--- a/doltpy/etl/__init__.py
+++ b/doltpy/etl/__init__.py
@@ -1,10 +1,11 @@
 from .dolthub_loader import main as dolthub_loader_main, loader as dolthub_loader
 from .dolt_loader import main as dolt_loader_main, loader as dolt_loader
-from .loaders import (get_df_table_loader,
-                      get_bulk_table_loader,
+from .loaders import (get_df_table_writer,
+                      get_bulk_table_writer,
                       get_dolt_loader,
                       get_table_transfomer,
-                      load_to_dolt,
                       insert_unique_key,
                       resolve_function,
-                      DoltTableLoader)
+                      DoltTableWriter,
+                      DoltLoader,
+                      DoltLoaderBuilder)

--- a/doltpy/etl/__init__.py
+++ b/doltpy/etl/__init__.py
@@ -3,6 +3,7 @@ from .dolt_loader import main as dolt_loader_main, loader as dolt_loader
 from .loaders import (get_df_table_writer,
                       get_bulk_table_writer,
                       get_dolt_loader,
+                      get_branch_creator,
                       get_table_transfomer,
                       insert_unique_key,
                       resolve_function,

--- a/doltpy/etl/dolt_loader.py
+++ b/doltpy/etl/dolt_loader.py
@@ -1,26 +1,25 @@
 import argparse
 from doltpy.core import Dolt
 from typing import List
-from doltpy.etl.loaders import load_to_dolt, resolve_function, DoltTableLoader, resolve_branch
+from doltpy.etl.loaders import resolve_function, DoltLoaderBuilder
 import logging
 from doltpy.etl.cli_logging_config_helper import config_cli_logger
 
 logger = logging.getLogger(__name__)
 
 
-def loader(loaders: List[DoltTableLoader], dolt_dir: str, commit: bool, message: str, dry_run: bool, branch: str):
+def loader(loader_builder: DoltLoaderBuilder, dolt_dir: str, dry_run: bool):
     logger.info(
         '''Commencing load to Dolt with the following options, and the following options
                 - dolt_dir  {dolt_dir}
-                - commit    {commit}
-                - branch    {branch}
-        '''.format(dolt_dir=dolt_dir,
-                   commit=commit,
-                   branch=branch)
+        '''.format(dolt_dir=dolt_dir)
     )
 
     if not dry_run:
-        load_to_dolt(Dolt(dolt_dir), loaders, commit, message, branch)
+        if not dry_run:
+            loaders = loader_builder()
+            for dolt_loader in loaders:
+                dolt_loader(Dolt(dolt_dir))
 
 
 def main():
@@ -28,19 +27,10 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('dolt_load_module', help='Fully qualified path to a module providing a set of loaders')
     parser.add_argument('--dolt-dir', type=str, help='The directory of the Dolt repo being loaded to', required=True)
-    parser.add_argument('--commit', action='store_true')
-    parser.add_argument('--message', type=str, help='Commit message to assciate created commit (requires --commit)')
-    parser.add_argument('--branch', type=str, help='Branch to write to, default is master')
-    parser.add_argument('--branch-generator', type=str, help='A module path to generate a branch name programmatically')
     parser.add_argument('--dry-run', action='store_true', help="Print out parameters, but don't do anything")
     args = parser.parse_args()
     logger.info('Resolving loaders for module path {}'.format(args.dolt_load_module))
-    loader(loaders=resolve_function(args.dolt_load_module),
-           dolt_dir=args.dolt_dir,
-           commit=args.commit,
-           message=args.message,
-           dry_run=args.dry_run,
-           branch=resolve_branch(args.branch, args.branch_generator, 'master'))
+    loader(loader_builder=resolve_function(args.dolt_load_module), dolt_dir=args.dolt_dir, dry_run=args.dry_run)
 
 
 if __name__ == '__main__':

--- a/doltpy/etl/dolt_loader.py
+++ b/doltpy/etl/dolt_loader.py
@@ -10,16 +10,15 @@ logger = logging.getLogger(__name__)
 
 def loader(loader_builder: DoltLoaderBuilder, dolt_dir: str, dry_run: bool):
     logger.info(
-        '''Commencing load to Dolt with the following options, and the following options
+        '''Commencing load to Dolt with the following options:
                 - dolt_dir  {dolt_dir}
         '''.format(dolt_dir=dolt_dir)
     )
 
     if not dry_run:
-        if not dry_run:
-            loaders = loader_builder()
-            for dolt_loader in loaders:
-                dolt_loader(Dolt(dolt_dir))
+        loaders = loader_builder()
+        for dolt_loader in loaders:
+            dolt_loader(Dolt(dolt_dir))
 
 
 def main():

--- a/doltpy/etl/dolthub_loader.py
+++ b/doltpy/etl/dolthub_loader.py
@@ -29,7 +29,7 @@ def loader(loader_builder: DoltLoaderBuilder,
         repo = Dolt(dolt_dir)
 
     logger.info(
-        '''Commencing to load to DoltHub with the following options, and the following options
+        '''Commencing to load to DoltHub with the following options:
                         - dolt_dir  {dolt_dir}
                         - clone     {clone}
                         - remote    {remote}
@@ -56,7 +56,7 @@ def main():
     parser.add_argument('--clone', action='store_true', help='Clone the remote to the local machine')
     parser.add_argument('--remote-url', type=str, help='DoltHub remote being used', required=True)
     parser.add_argument('--remote-name', type=str, default='origin', help='Alias for remote, default is origin')
-    parser.add_argument('--push', action='store_true', help='Push changes to remote, must sepcify arg --remote')
+    parser.add_argument('--push', action='store_true', help='Push changes to remote, must specify arg --remote')
     parser.add_argument('--dry-run', action='store_true', help="Print out parameters, but don't do anything")
     args = parser.parse_args()
     logger.info('Resolving loaders for module path {}'.format(args.dolt_load_module))

--- a/doltpy/etl/dolthub_loader.py
+++ b/doltpy/etl/dolthub_loader.py
@@ -49,7 +49,6 @@ def loader(loaders: List[DoltTableLoader],
 
     if not dry_run:
         load_to_dolt(repo, loaders, commit, message, branch)
-
         if push:
             logger.info('Pushing changes to remote {} on branch {}'.format(remote_name, branch))
             repo.push(remote_name, branch)

--- a/doltpy/etl/dolthub_loader.py
+++ b/doltpy/etl/dolthub_loader.py
@@ -2,22 +2,18 @@ import argparse
 from doltpy.core import Dolt
 import os
 import tempfile
-from doltpy.etl.loaders import load_to_dolt, resolve_function, DoltTableLoader, resolve_branch
-from typing import List
+from doltpy.etl.loaders import resolve_function, DoltLoaderBuilder
 import logging
 from doltpy.etl.cli_logging_config_helper import config_cli_logger
 
 logger = logging.getLogger(__name__)
 
 
-def loader(loaders: List[DoltTableLoader],
+def loader(loader_builder: DoltLoaderBuilder,
            dolt_dir: str,
            clone: bool,
-           branch: str,
-           commit: bool,
            push: bool,
            remote_name: str,
-           message: str,
            dry_run: bool,
            remote_url: str):
     if clone:
@@ -35,23 +31,21 @@ def loader(loaders: List[DoltTableLoader],
     logger.info(
         '''Commencing to load to DoltHub with the following options, and the following options
                         - dolt_dir  {dolt_dir}
-                        - commit    {commit}
-                        - branch    {branch}
                         - clone     {clone}
                         - remote    {remote}
                         - push      {push}
         '''.format(dolt_dir=repo.repo_dir,
-                   commit=commit,
-                   branch=branch,
                    push=push,
                    clone=clone,
                    remote=remote_name))
 
     if not dry_run:
-        load_to_dolt(repo, loaders, commit, message, branch)
-        if push:
-            logger.info('Pushing changes to remote {} on branch {}'.format(remote_name, branch))
-            repo.push(remote_name, branch)
+        loaders = loader_builder()
+        for dolt_loader in loaders:
+            branch = dolt_loader(repo)
+            if push:
+                logger.info('Pushing changes to remote {} on branch {}'.format(remote_name, branch))
+                repo.push(remote_name, branch)
 
 
 def main():
@@ -59,10 +53,6 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('dolt_load_module', help='Fully qualified path to a module providing a set of loaders')
     parser.add_argument('--dolt-dir', type=str, help='The directory of the Dolt repo being loaded to')
-    parser.add_argument('--commit', action='store_true')
-    parser.add_argument('--message', type=str, help=' Commit message to assciate created commit (requires --commit)')
-    parser.add_argument('--branch', type=str, help='Branch to write to, default is master')
-    parser.add_argument('--branch-generator', type=str, help='A module path to generate a branch name programmatically')
     parser.add_argument('--clone', action='store_true', help='Clone the remote to the local machine')
     parser.add_argument('--remote-url', type=str, help='DoltHub remote being used', required=True)
     parser.add_argument('--remote-name', type=str, default='origin', help='Alias for remote, default is origin')
@@ -70,15 +60,12 @@ def main():
     parser.add_argument('--dry-run', action='store_true', help="Print out parameters, but don't do anything")
     args = parser.parse_args()
     logger.info('Resolving loaders for module path {}'.format(args.dolt_load_module))
-    loader(loaders=resolve_function(args.dolt_load_module),
+    loader(loader_builder=resolve_function(args.dolt_load_module),
            dolt_dir=args.dolt_dir,
            clone=args.clone,
-           commit=args.commit,
            push=args.push,
            remote_name=args.remote_name,
-           message=args.message,
            dry_run=args.dry_run,
-           branch=resolve_branch(args.branch, args.branch_generator, 'master'),
            remote_url=args.remote_url)
 
 

--- a/doltpy/etl/loaders.py
+++ b/doltpy/etl/loaders.py
@@ -155,6 +155,9 @@ def get_dolt_loader(repo: Dolt,
     def inner():
         original_branch = repo.get_current_branch()
 
+        if branch != original_branch and not commit:
+            raise ValueError('If writes are to another branch, and commit is not True, writes will be lost')
+
         if repo.get_current_branch() != branch:
             logger.info('Current branch is {}, checking out {}'.format(repo.get_current_branch(), branch))
             if branch not in repo.get_branch_list():

--- a/doltpy/etl/loaders.py
+++ b/doltpy/etl/loaders.py
@@ -6,7 +6,9 @@ import hashlib
 import importlib
 import logging
 
-DoltTableLoader = Callable[[Dolt], str]
+DoltTableWriter = Callable[[Dolt], str]
+DoltLoader = Callable[[Dolt], str]
+DoltLoaderBuilder = Callable[[], List[DoltLoader]]
 DataframeTransformer = Callable[[pd.DataFrame], pd.DataFrame]
 FileTransformer = Callable[[io.StringIO], io.StringIO]
 
@@ -74,11 +76,11 @@ def _apply_file_transformers(data: io.StringIO, transformers: List[FileTransform
     return temp
 
 
-def get_bulk_table_loader(table: str,
+def get_bulk_table_writer(table: str,
                           get_data: Callable[[], io.StringIO],
                           pk_cols: List[str],
                           import_mode: str = None,
-                          transformers: List[FileTransformer] = None) -> DoltTableLoader:
+                          transformers: List[FileTransformer] = None) -> DoltTableWriter:
     """
     Returns a loader function that writes a file-like object to Dolt, the file must be a valid CSV file.
     :param table:
@@ -97,11 +99,11 @@ def get_bulk_table_loader(table: str,
     return inner
 
 
-def get_df_table_loader(table: str,
+def get_df_table_writer(table: str,
                         get_data: Callable[[], pd.DataFrame],
                         pk_cols: List[str],
                         import_mode: str = None,
-                        transformers: List[DataframeTransformer] = None) -> DoltTableLoader:
+                        transformers: List[DataframeTransformer] = None) -> DoltTableWriter:
     """
     Returns a loader that writes the `pd.DataFrame` produced by get_data to Dolt.
     :param table:
@@ -134,25 +136,23 @@ def get_table_transfomer(get_data: Callable[[Dolt], pd.DataFrame],
     return inner
 
 
-def get_dolt_loader(repo: Dolt,
-                    table_loaders: List[DoltTableLoader],
+def get_dolt_loader(table_writers: List[DoltTableWriter],
                     commit: bool,
                     message: str,
                     branch: str = 'master',
-                    transaction_mode: bool = None):
+                    transaction_mode: bool = None) -> DoltLoader:
     """
     Given a repo and a set of table loaders, run the table loaders and conditionally commit the results with the
     specified message on the specified branch. If transaction_mode is true then ensure all loaders/transformers are
     successful, or all are rolled back.
-    :param repo:
-    :param table_loaders:
+    :param table_writers:
     :param commit:
     :param message:
     :param branch:
     :param transaction_mode:
-    :return:
+    :return: the branch written to
     """
-    def inner():
+    def inner(repo: Dolt):
         original_branch = repo.get_current_branch()
 
         if branch != original_branch and not commit:
@@ -168,7 +168,7 @@ def get_dolt_loader(repo: Dolt,
         if transaction_mode:
             raise NotImplementedError('transaction_mode is not yet implemented')
 
-        tables_updated = [loader(repo) for loader in table_loaders]
+        tables_updated = [writer(repo) for writer in table_writers]
 
         if commit:
             logger.info('Committing to repo located in {} for tables:\n{}'.format(repo.repo_dir, tables_updated))
@@ -182,13 +182,6 @@ def get_dolt_loader(repo: Dolt,
                                                                                           original_branch))
             repo.checkout(original_branch)
 
+        return branch
+
     return inner
-
-
-def load_to_dolt(repo: Dolt,
-                 table_loaders: List[DoltTableLoader],
-                 commit: bool,
-                 message: str,
-                 branch: str = 'master',
-                 transaction_mode: bool = None):
-    get_dolt_loader(repo, table_loaders, commit, message, branch, transaction_mode)()

--- a/doltpy/etl/loaders.py
+++ b/doltpy/etl/loaders.py
@@ -126,7 +126,7 @@ def get_table_transfomer(get_data: Callable[[Dolt], pd.DataFrame],
                          target_table: str,
                          target_pk_cols: List[str],
                          transformer: DataframeTransformer,
-                         import_mode: str = UPDATE):
+                         import_mode: str = UPDATE) -> DoltTableWriter:
     def inner(repo: Dolt):
         input_data = get_data(repo)
         transformed_data = transformer(input_data)

--- a/doltpy/etl/loaders.py
+++ b/doltpy/etl/loaders.py
@@ -185,3 +185,15 @@ def get_dolt_loader(table_writers: List[DoltTableWriter],
         return branch
 
     return inner
+
+
+def get_branch_creator(new_branch_name: str, refspec: str = None):
+    def inner(repo: Dolt):
+        assert new_branch_name not in repo.get_branch_list(), 'Branch {} already exists'.format(new_branch_name)
+        logger.info('Creating new branch on repo in {} named {} at refspec {}'.format(repo.repo_dir,
+                                                                                      new_branch_name,
+                                                                                      refspec))
+        repo.create_branch(new_branch_name, refspec)
+
+    return inner
+

--- a/doltpy/etl/tests/test_tools.py
+++ b/doltpy/etl/tests/test_tools.py
@@ -6,7 +6,8 @@ from doltpy.etl import (get_df_table_writer,
                         insert_unique_key,
                         get_table_transfomer,
                         get_bulk_table_writer,
-                        get_dolt_loader)
+                        get_dolt_loader,
+                        get_branch_creator)
 from doltpy.core.tests.dolt_testing_fixtures import init_repo
 
 
@@ -238,3 +239,9 @@ def test_multi_branch_load(initial_test_data):
     assert 'Steffi' in list(womens_data['name']) and 'Novak' in list(mens_data['name'])
 
 
+def test_branch_creator(initial_test_data):
+    repo = initial_test_data
+    new_branch = 'new-branch'
+    assert repo.get_branch_list() == ['master']
+    get_branch_creator(new_branch)(repo)
+    assert new_branch in repo.get_branch_list()

--- a/doltpy/etl/tests/test_tools.py
+++ b/doltpy/etl/tests/test_tools.py
@@ -16,6 +16,8 @@ INITIAL_WOMENS = pd.DataFrame({'name': ['Serena'], 'major_count': [23]})
 INITIAL_MENS = pd.DataFrame({'name': ['Roger'], 'major_count': [20]})
 UPDATE_WOMENS = pd.DataFrame({'name': ['Margaret'], 'major_count': [24]})
 UPDATE_MENS = pd.DataFrame({'name': ['Rafael'], 'major_count': [19]})
+SECOND_UPDATE_WOMENS = pd.DataFrame({'name': ['Steffi'], 'major_count': [22]})
+SECOND_UPDATE_MENS = pd.DataFrame({'name': ['Novak'], 'major_count': [16]})
 
 
 def _populate_test_data_helper(repo: Dolt, mens: pd.DataFrame, womens: pd.DataFrame, branch: str = 'master'):
@@ -213,5 +215,26 @@ def test_load_to_dolt_new_branch(initial_test_data):
     # check out our new branch and confirm our data is present
     repo.checkout(test_branch)
     womens_data, mens_data = repo.read_table(WOMENS_MAJOR_COUNT), repo.read_table(MENS_MAJOR_COUNT)
-    assert 'Margaret' in list(womens_data['name'])
-    assert 'Rafael' in list(mens_data['name'])
+    assert 'Margaret' in list(womens_data['name']) and 'Rafael' in list(mens_data['name'])
+
+
+def test_multi_branch_load(initial_test_data):
+    repo = initial_test_data
+    first_branch, second_branch = 'first-branch', 'second-branch'
+
+    _populate_test_data_helper(repo, UPDATE_MENS, UPDATE_WOMENS, first_branch)
+    _populate_test_data_helper(repo, SECOND_UPDATE_MENS, SECOND_UPDATE_WOMENS, second_branch)
+
+    womens_data, mens_data = repo.read_table(WOMENS_MAJOR_COUNT), repo.read_table(MENS_MAJOR_COUNT)
+    assert 'Margaret' not in list(womens_data['name']) and 'Rafael' not in list(mens_data['name'])
+    assert 'Steffi' not in list(womens_data['name']) and 'Novak' not in list(mens_data['name'])
+
+    repo.checkout(first_branch)
+    womens_data, mens_data = repo.read_table(WOMENS_MAJOR_COUNT), repo.read_table(MENS_MAJOR_COUNT)
+    assert 'Margaret' in list(womens_data['name']) and 'Rafael' in list(mens_data['name'])
+
+    repo.checkout(second_branch)
+    womens_data, mens_data = repo.read_table(WOMENS_MAJOR_COUNT), repo.read_table(MENS_MAJOR_COUNT)
+    assert 'Steffi' in list(womens_data['name']) and 'Novak' in list(mens_data['name'])
+
+

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,14 @@
 from setuptools import setup, find_packages
 
 setup(name='doltpy',
-      version='0.0.2',
+      version='0.0.3',
       packages=find_packages(),
       install_requires=['pandas>=0.25.0', 'pyarrow>=0.14.1', 'mysql-connector-python==8.0.17', 'retry>=0.9.2'],
       author='Liquidata',
       author_email='oscar@liquidata.co',
       description='A Python package for using Dolt database via Python.',
       url='https://github.com/liquidata-inc/doltpy',
-      download_url='https://github.com/liquidata-inc/doltpy/archive/v0.0.1.tar.gz',
+      download_url='https://github.com/liquidata-inc/doltpy/archive/v0.0.3.tar.gz',
       keywords=['Dolt', 'Liquidata', 'DoltHub', 'ETL', 'ELT'],
       project_urls={'Bug Tracker': 'https://github.com /liquidata-inc/core/issues'},
       entry_points={


### PR DESCRIPTION
This is a substantial change in the semantics:
- "table loaders" are now writers
- loaders manage running writers
- branch, commit managed at loader level
- many loads can be passed into a single DoltHub load

The idea is that we can clone a repo, load data to a branch, push it, and then repeat with another branch, thus amortizing the cloning I/O over many loads (h/t @tbantle22 for raising this use case).