### PR TITLE
Remove condition preventing server context in unclean repo

### DIFF
--- a/doltpy/sql/sql.py
+++ b/doltpy/sql/sql.py
@@ -373,9 +373,6 @@ class DoltSQLServerContext(DoltSQLContext):
         self.checkout_branch = None
 
     def __enter__(self):
-        if not self.dolt.status().is_clean:
-            # TODO better error messages
-            raise ValueError("DoltSQLServerManager does not support ")
         if self.server_config.branch:
             current_branch, _ = self.dolt.branch()
             if current_branch.name != self.server_config.branch:


### PR DESCRIPTION
Tentatively closes #181.

This is mostly to see if removing it breaks any existing tests (and if not, if it should be breaking any tests). I'm not sure this is a valid solution since I don't understand the purpose of the condition. @oscarbatori Could you confirm if this is correct?